### PR TITLE
Enhance/input

### DIFF
--- a/context.go
+++ b/context.go
@@ -125,23 +125,20 @@ func (c *Context) updateIME(oldW, newW Widget) {
 		return
 	}
 
-	// note: the code isn't monitoring IME option changes within the same
-	// widget or anything. users could call Show()/Hide() directly on the
-	// IME bridge too, so we can't reliably cache such state anyway without
-	// more methods on android's side
-	var oldOpts, newOpts IMEOptions
+	// note: IME shown status can't be reliable monitored. Users can call
+	// Show()/Hide() on their own, and Android also doesn't expose this
+	var opts IMEOptions
 	var hadIME, hasIME bool
-	if oldW != nil {
-		if w, ok := oldW.(IME); ok {
-			oldOpts = w.IME()
+	if oldW != nil && oldW.IsEnabled() {
+		if _, ok := oldW.(IME); ok {
 			hadIME = true
 		}
 	}
 
-	if newW != nil {
+	if newW != nil && newW.IsEnabled() {
 		if w, ok := newW.(IME); ok {
 			hasIME = true
-			newOpts = w.IME()
+			opts = w.IME()
 		}
 	}
 
@@ -149,8 +146,8 @@ func (c *Context) updateIME(oldW, newW Widget) {
 		c.ime.Hide()
 	}
 
-	if hasIME && (!hadIME || oldOpts != newOpts) {
-		inType, imeOpts := newOpts.AndroidParameters()
+	if hasIME {
+		inType, imeOpts := opts.AndroidParameters()
 		c.ime.Show(inType, imeOpts)
 	}
 }

--- a/demo/game.go
+++ b/demo/game.go
@@ -96,6 +96,11 @@ func (g *Game) initOnce() {
 	g.txtType = widget.NewSelect(g.theme, imeSelOpts)
 	g.txtType.MaxVisible = len(imeSelOpts)
 	g.txtA = widget.NewTextInput(g.theme, "Type here…")
+	g.txtA.On(uikit.EventPointerDown, func(e uikit.Event) bool {
+		index := g.txtA.ClosestCaretIndex(e.Pointer.Position.X)
+		g.txtA.SetCaret(index)
+		return true
+	}, false)
 	g.txtType.On(uikit.EventValueChange, func(e uikit.Event) bool {
 		s, isSelected := g.txtType.Selected()
 		if isSelected {

--- a/demo/game.go
+++ b/demo/game.go
@@ -96,6 +96,7 @@ func (g *Game) initOnce() {
 	g.txtType = widget.NewSelect(g.theme, imeSelOpts)
 	g.txtType.MaxVisible = len(imeSelOpts)
 	g.txtA = widget.NewTextInput(g.theme, "Type here…")
+	g.txtA.SetInputRuneLimit(22)
 	g.txtType.On(uikit.EventValueChange, func(e uikit.Event) bool {
 		s, isSelected := g.txtType.Selected()
 		if isSelected {

--- a/demo/game.go
+++ b/demo/game.go
@@ -96,11 +96,6 @@ func (g *Game) initOnce() {
 	g.txtType = widget.NewSelect(g.theme, imeSelOpts)
 	g.txtType.MaxVisible = len(imeSelOpts)
 	g.txtA = widget.NewTextInput(g.theme, "Type here…")
-	g.txtA.On(uikit.EventPointerDown, func(e uikit.Event) bool {
-		index := g.txtA.ClosestCaretIndex(e.Pointer.Position.X)
-		g.txtA.SetCaret(index)
-		return true
-	}, false)
 	g.txtType.On(uikit.EventValueChange, func(e uikit.Event) bool {
 		s, isSelected := g.txtType.Selected()
 		if isSelected {

--- a/widget/input_helpers.go
+++ b/widget/input_helpers.go
@@ -1,7 +1,6 @@
 package widget
 
 import (
-	"math"
 	"time"
 	"unicode"
 	"unicode/utf8"
@@ -12,7 +11,7 @@ import (
 
 // blink ticks returns the length of "blink on", which equals "blink off"
 func blinkTicks(theme *uikit.Theme) int {
-	return int(math.Max(1, float64(theme.CaretBlink*time.Duration(ebiten.TPS()))/float64(time.Second)))
+	return int(float64(theme.CaretBlink*time.Duration(ebiten.TPS())) / float64(time.Second))
 }
 
 // removeLastRune removes the last UTF-8 rune from the provided string.

--- a/widget/input_helpers.go
+++ b/widget/input_helpers.go
@@ -1,0 +1,111 @@
+package widget
+
+import (
+	"math"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/bstkhq/go-uikit"
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+// blink ticks returns the length of "blink on", which equals "blink off"
+func blinkTicks(theme *uikit.Theme) int {
+	return int(math.Max(1, float64(theme.CaretBlink*time.Duration(ebiten.TPS()))/float64(time.Second)))
+}
+
+// removeLastRune removes the last UTF-8 rune from the provided string.
+func removeLastRune(s string) string {
+	if s == "" {
+		return ""
+	}
+	_, sz := utf8.DecodeLastRuneInString(s)
+	if sz <= 0 || sz > len(s) {
+		return ""
+	}
+	return s[:len(s)-sz]
+}
+
+type runeClass int
+
+const (
+	runeNone runeClass = iota
+	runeSpace
+	runeAlphanum
+	runeConnector
+	runePunctuation
+)
+
+func runeBreakClass(r rune) runeClass {
+	for _, class := range []runeClass{runeSpace, runeAlphanum, runeConnector, runePunctuation} {
+		if isRuneClass(r, class) {
+			return class
+		}
+	}
+	return runeNone
+}
+
+func isRuneClass(r rune, class runeClass) bool {
+	switch class {
+	case runeSpace:
+		return unicode.In(r, unicode.Space)
+	case runeAlphanum:
+		return unicode.In(r, unicode.Letter, unicode.Number)
+	case runeConnector:
+		return unicode.In(r, unicode.Pc)
+	case runePunctuation:
+		return unicode.In(r, unicode.P) && !unicode.In(r, unicode.Pc)
+	case runeNone:
+		return !unicode.In(r, unicode.Letter, unicode.Number, unicode.P)
+	default:
+		panic(class)
+	}
+}
+
+func prevBreakPos(runes []rune, pos int) int {
+	if pos <= 1 || pos > len(runes) {
+		return 0
+	}
+
+	pos -= 1
+	if unicode.IsSpace(runes[pos]) || isRuneClass(runes[pos], runeConnector) {
+		pos -= 1
+		if pos <= 1 {
+			return 0
+		}
+	}
+
+	matchClass := runeBreakClass(runes[pos])
+	for pos > 0 {
+		if isRuneClass(runes[pos-1], matchClass) {
+			pos -= 1
+			continue
+		}
+		return pos
+	}
+	return 0
+}
+
+func nextBreakPos(runes []rune, pos int) int {
+	if pos >= len(runes) {
+		return len(runes)
+	}
+
+	if unicode.IsSpace(runes[pos]) || isRuneClass(runes[pos], runeConnector) {
+		pos += 1
+		if pos >= len(runes) {
+			return len(runes)
+		}
+	}
+
+	matchClass := runeBreakClass(runes[pos])
+	for pos < len(runes) {
+		if isRuneClass(runes[pos], matchClass) {
+			pos += 1
+			continue
+		}
+		return pos
+	}
+	return len(runes)
+}

--- a/widget/textinput.go
+++ b/widget/textinput.go
@@ -77,14 +77,6 @@ func (w *TextInput) SetTextSilently(s string) {
 	w.scrollPos = max(0, w.scrollPos)
 }
 
-// AppendText appends a string to the current text and dispatches a value-change event.
-func (w *TextInput) AppendText(s string) {
-	if s == "" {
-		return
-	}
-	w.SetText(w.text + s)
-}
-
 // Caret returns the current caret index, in runes.
 func (w *TextInput) Caret() int {
 	return w.caretPos

--- a/widget/textinput.go
+++ b/widget/textinput.go
@@ -156,7 +156,18 @@ func (w *TextInput) Update(ctx *uikit.Context) {
 		}
 	}
 
-	if !w.IsFocused() || !w.IsEnabled() {
+	if !w.IsEnabled() {
+		return
+	}
+
+	ptr := ctx.Pointer()
+	if ptr.IsDown && ptr.Position.In(w.Measure(false)) {
+		w.caretTick = 0
+		index := w.ClosestCaretIndex(ptr.Position.X)
+		w.SetCaret(index)
+	}
+
+	if !w.IsFocused() {
 		return
 	}
 

--- a/widget/textinput.go
+++ b/widget/textinput.go
@@ -1,15 +1,15 @@
 package widget
 
 import (
+	"image"
 	"math"
-	"time"
-	"unicode/utf8"
+	"slices"
 
 	"github.com/bstkhq/go-uikit"
 	"github.com/bstkhq/go-uikit/common"
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/inpututil"
-	"github.com/hajimehoshi/ebiten/v2/vector"
+	"github.com/tinne26/etxt"
 )
 
 var _ uikit.Widget = (*TextInput)(nil)
@@ -22,11 +22,15 @@ type TextInput struct {
 	text        string
 	placeholder string
 	caretTick   int
+	caretPos    int
+	scrollPos   int  // in runes
+	anchorRight bool // for scrollPos
+	wasFocused  bool
 
 	IMEOptions uikit.IMEOptions
 
 	// Reusable buffers to avoid allocations on every Update().
-	inputBuf  []rune
+	textRunes []rune
 	appendBuf []rune
 }
 
@@ -50,14 +54,25 @@ func (w *TextInput) SetText(s string) {
 	if w.text == s {
 		return
 	}
-	w.text = s
+
+	w.SetTextSilently(s)
 	w.Dispatch(uikit.Event{Widget: w, Type: uikit.EventValueChange})
 }
 
 // SetTextSilently sets the current text value without dispatching events.
 // Useful internally to batch changes and dispatch once.
 func (w *TextInput) SetTextSilently(s string) {
+	if w.text == s {
+		return
+	}
+
 	w.text = s
+	w.textRunes = w.textRunes[:0]
+	for _, r := range s {
+		w.textRunes = append(w.textRunes, r)
+	}
+	w.caretPos = min(w.caretPos, len(w.textRunes))
+	w.scrollPos = max(0, w.scrollPos)
 }
 
 // AppendText appends a string to the current text and dispatches a value-change event.
@@ -70,155 +85,205 @@ func (w *TextInput) AppendText(s string) {
 
 // Reset clears the current text.
 func (w *TextInput) Reset() {
+	w.wasFocused = false
 	w.SetText("")
 }
 
-// removeLastRune removes the last UTF-8 rune from the provided string.
-func removeLastRune(s string) string {
-	if s == "" {
-		return ""
-	}
-	_, sz := utf8.DecodeLastRuneInString(s)
-	if sz <= 0 || sz > len(s) {
-		return ""
-	}
-	return s[:len(s)-sz]
-}
-
 func (w *TextInput) Update(ctx *uikit.Context) {
-	focused := w.IsFocused()
-	enabled := w.IsEnabled()
-
-	if focused && enabled {
-		w.caretTick++
-	} else {
-		w.caretTick = 0
+	w.caretTick += 1
+	if w.wasFocused != w.IsFocused() {
+		if !w.wasFocused {
+			w.caretTick = 0
+			w.wasFocused = !w.wasFocused
+		}
 	}
 
-	if !focused || !enabled {
+	if !w.IsFocused() || !w.IsEnabled() {
 		return
 	}
 
-	original := w.text
-	text := original
-
-	// Reuse buffer to avoid allocations.
-	w.inputBuf = ebiten.AppendInputChars(w.inputBuf[:0])
-
-	// Batch normal runes to avoid repeated string concatenations.
-	w.appendBuf = w.appendBuf[:0]
-
-	flushAppend := func() {
-		if len(w.appendBuf) == 0 {
-			return
+	var changed bool
+	w.appendBuf = ebiten.AppendInputChars(w.appendBuf[:0])
+	for _, r := range w.appendBuf {
+		switch {
+		case r == 0x08: // BS
+			changed = w.deleteRuneBS() || changed
+		case r == 0x7f: // DEL
+			changed = w.deleteRuneDEL() || changed
+		case r >= 0x20: // append runes >= ' ' (ignore control chars)
+			w.textRunes = slices.Insert(w.textRunes, w.caretPos, r) // could be optimized
+			w.caretPos += 1
+			changed = true
 		}
-		text += string(w.appendBuf)
-		w.appendBuf = w.appendBuf[:0]
 	}
 
-	// IME / input chars
-	for _, ch := range w.inputBuf {
-		// Backspace can arrive as '\b' or DEL.
-		if ch == '\b' || ch == 0x7f {
-			flushAppend()
-			text = removeLastRune(text)
-			continue
-		}
+	// handle other special keys
+	if inpututil.IsKeyJustPressed(ebiten.KeyBackspace) {
+		changed = w.deleteRuneBS() || changed
+	}
+	if inpututil.IsKeyJustPressed(ebiten.KeyDelete) {
+		changed = w.deleteRuneDEL() || changed
+	}
+	w.updateNav()
 
-		// Skip control characters.
-		if ch < 0x20 {
-			continue
-		}
-
-		w.appendBuf = append(w.appendBuf, ch)
+	// update text and dispatch changes
+	if changed {
+		w.caretTick = 0
+		w.text = string(w.textRunes)
+		w.Dispatch(uikit.Event{Widget: w, Type: uikit.EventValueChange})
 	}
 
-	flushAppend()
-
-	// Desktop / fallback backspace handling (Android IME can be inconsistent).
-	if inpututil.IsKeyJustPressed(ebiten.KeyBackspace) || inpututil.IsKeyJustPressed(ebiten.KeyDelete) {
-		text = removeLastRune(text)
-	}
-
-	// Commit focus changes (no text modification).
+	// remove focus on Enter
 	if inpututil.IsKeyJustPressed(ebiten.KeyEnter) || inpututil.IsKeyJustPressed(ebiten.KeyKPEnter) {
 		ctx.SetFocus(nil)
 	}
+}
 
-	// Dispatch only once if something actually changed.
-	if text != original {
-		w.SetText(text)
+func (w *TextInput) updateNav() {
+	if inpututil.IsKeyJustPressed(ebiten.KeyArrowLeft) {
+		w.caretTick = 0
+		if w.caretPos > 0 {
+			if ebiten.IsKeyPressed(ebiten.KeyControl) {
+				w.caretPos = prevBreakPos(w.textRunes, w.caretPos)
+			} else {
+				w.caretPos -= 1
+			}
+		}
+	} else if inpututil.IsKeyJustPressed(ebiten.KeyArrowRight) {
+		w.caretTick = 0
+		if w.caretPos < len(w.textRunes) {
+			if ebiten.IsKeyPressed(ebiten.KeyControl) {
+				w.caretPos = nextBreakPos(w.textRunes, w.caretPos)
+			} else {
+				w.caretPos += 1
+			}
+		}
+	}
+	if inpututil.IsKeyJustPressed(ebiten.KeyHome) || inpututil.IsKeyJustPressed(ebiten.KeyPageUp) {
+		w.caretPos = 0
+		w.caretTick = 0
+	} else if inpututil.IsKeyJustPressed(ebiten.KeyEnd) || inpututil.IsKeyJustPressed(ebiten.KeyPageDown) {
+		w.caretPos = len(w.textRunes)
+		w.caretTick = 0
 	}
 }
 
+func (w *TextInput) deleteRuneBS() bool {
+	if len(w.textRunes) == 0 || w.caretPos <= 0 {
+		return false
+	}
+	start := w.caretPos - 1
+	if ebiten.IsKeyPressed(ebiten.KeyControl) {
+		start = prevBreakPos(w.textRunes, w.caretPos)
+	}
+	w.textRunes = slices.Delete(w.textRunes, start, w.caretPos)
+	w.caretPos -= (w.caretPos - start)
+	return true
+}
+
+func (w *TextInput) deleteRuneDEL() bool {
+	if len(w.textRunes) == 0 {
+		return false
+	}
+	if w.caretPos >= len(w.textRunes) {
+		return w.deleteRuneBS()
+	}
+
+	end := w.caretPos + 1
+	if ebiten.IsKeyPressed(ebiten.KeyControl) {
+		end = nextBreakPos(w.textRunes, w.caretPos)
+	}
+
+	w.textRunes = slices.Delete(w.textRunes, w.caretPos, end)
+	return true
+}
+
 func (w *TextInput) Draw(ctx *uikit.Context, dst *ebiten.Image) {
-	w.Base.Draw(ctx, dst)
-
+	r := w.Base.Draw(ctx, dst)
 	theme := ctx.Theme()
-	r := w.Measure(false)
+	cy := r.Min.Y + r.Dy()/2
+	r = common.Inset(r, theme.PadX, theme.PadY)
 
-	content := common.Inset(r, theme.PadX, theme.PadY)
-	middleY := r.Min.Y + r.Dy()/2
-
-	// Decide what to render: actual text or placeholder.
-	drawStr := w.text
-	textCol := theme.TextColor
-	if drawStr == "" && !w.IsFocused() {
-		drawStr = w.placeholder
-		textCol = theme.MutedTextColor
+	// if no text and unfocused, draw placeholder
+	renderer := theme.Text()
+	if len(w.textRunes) == 0 && !w.IsFocused() {
+		if w.placeholder != "" {
+			renderer.SetColor(theme.MutedTextColor)
+			renderer.Draw(dst, w.placeholder, r.Min.X, cy)
+		}
+		return
 	}
 
-	t := theme.Text()
-
-	// Horizontal overflow handling (keep the end visible).
-	m := t.Measure(drawStr)
-	textW := m.ImageRect().Dx()
-
-	shiftX := 0
-	if textW > content.Dx() {
-		shiftX = content.Dx() - textW
+	// find caret and scroll anchor positions
+	feed := etxt.NewFeed(renderer)
+	caretShift, scrollShift := -1, -1
+	for i, r := range w.textRunes {
+		if i == w.caretPos {
+			caretShift = feed.Position.X.ToIntFloor()
+			if scrollShift != -1 {
+				break
+			}
+		}
+		if i == w.scrollPos {
+			scrollShift = feed.Position.X.ToIntFloor()
+			if caretShift != -1 {
+				break
+			}
+		}
+		feed.Advance(r)
+	}
+	if caretShift == -1 {
+		caretShift = feed.Position.X.ToIntFloor()
+	}
+	if scrollShift == -1 {
+		scrollShift = feed.Position.X.ToIntFloor()
 	}
 
-	// Draw text centered vertically.
-	t.SetColor(textCol)
-	t.Draw(dst, drawStr, content.Min.X+shiftX, middleY)
-
-	// Caret drawing (end-of-text caret).
-	if w.IsFocused() && w.IsEnabled() && theme.CaretWidthPx > 0 {
-		blinkFrames := int(math.Max(1, float64(theme.CaretBlink)/float64(time.Second)*60.0))
-		if (w.caretTick/blinkFrames)%2 == 0 {
-			measureStr := w.text
-			if measureStr == "" {
-				measureStr = " "
-			}
-
-			mc := t.Measure(measureStr)
-
-			cx := content.Min.X + shiftX + mc.IntWidth() + theme.CaretMarginPx
-			if w.text == "" {
-				cx = content.Min.X + shiftX + theme.CaretMarginPx
-			}
-
-			caretH := mc.IntHeight()
-			cy := middleY - (caretH / 2)
-
-			// Clamp caret into content rect.
-			if cx < content.Min.X {
-				cx = content.Min.X
-			}
-			if cx > content.Min.X+content.Dx() {
-				cx = content.Min.X + content.Dx()
-			}
-
-			vector.DrawFilledRect(
-				dst,
-				float32(cx),
-				float32(cy),
-				float32(theme.CaretWidthPx),
-				float32(caretH),
-				theme.CaretColor,
-				false,
-			)
+	// adjust scroll to view area
+	width := r.Dx()
+	if w.anchorRight {
+		if scrollShift-caretShift > width { // switch to anchor left
+			w.anchorRight = false
+			w.scrollPos = w.caretPos
+			scrollShift = caretShift
+		} else if feed.Position.X.ToIntFloor() < width { // restore full left anchor
+			w.anchorRight = false
+			w.scrollPos = 0
+			scrollShift = 0
+		} else if w.caretPos > w.scrollPos { // expand right
+			w.scrollPos = w.caretPos
+			scrollShift = caretShift
+		}
+	} else { // anchor left
+		if caretShift-scrollShift > width { // switch to anchor right
+			w.anchorRight = true
+			w.scrollPos = w.caretPos
+			scrollShift = caretShift
+		} else if w.caretPos < w.scrollPos { // expand left
+			w.scrollPos = w.caretPos
+			scrollShift = caretShift
 		}
 	}
+
+	// draw text
+	shift := -scrollShift
+	if w.anchorRight {
+		shift += width
+	}
+	renderer.Draw(dst, w.text, r.Min.X+shift, cy)
+
+	// draw caret
+	if w.IsFocused() && w.IsEnabled() && theme.CaretWidthPx > 0 && w.blink(theme) {
+		lineHeight := int(math.Round(renderer.Utils().GetLineHeight()))
+		x := r.Min.X + caretShift + shift + theme.CaretMarginPx
+		cy -= (lineHeight / 2)
+		b := dst.Bounds()
+		cy -= b.Min.Y
+		x -= b.Min.X
+		w.Base.DrawRoundedRect(dst, image.Rect(x, cy, x+theme.CaretWidthPx, cy+lineHeight), 0, theme.CaretColor)
+	}
+}
+
+func (w *TextInput) blink(theme *uikit.Theme) bool {
+	return (w.caretTick/blinkTicks(theme))%2 == 0
 }

--- a/widget/textinput.go
+++ b/widget/textinput.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/inpututil"
 	"github.com/tinne26/etxt"
+	"github.com/tinne26/etxt/fract"
 )
 
 var _ uikit.Widget = (*TextInput)(nil)
@@ -81,6 +82,62 @@ func (w *TextInput) AppendText(s string) {
 		return
 	}
 	w.SetText(w.text + s)
+}
+
+// Caret returns the current caret index, in runes.
+func (w *TextInput) Caret() int {
+	return w.caretPos
+}
+
+// SetCaret manually changes the caret position, in runes.
+// Values out of range will be clamped.
+func (w *TextInput) SetCaret(index int) {
+	w.caretPos = min(max(index, 0), len(w.textRunes))
+}
+
+// ClosestCaretIndex performs hit testing to find the caret index
+// closest to the given X coordinate. Since TextInput only has one
+// line of text, the Y coordinate is not required.
+func (w *TextInput) ClosestCaretIndex(x int) int {
+	theme := w.Theme()
+	r := w.Measure(false)
+	r = r.Inset(theme.PadX)
+
+	if x <= r.Min.X {
+		return 0
+	}
+	if x >= r.Max.X {
+		return len(w.textRunes)
+	}
+
+	// find shift
+	feed := etxt.NewFeed(theme.Text())
+	for i, r := range w.textRunes {
+		if i == w.scrollPos {
+			break
+		}
+		feed.Advance(r)
+	}
+	shift := -feed.Position.X
+	if w.anchorRight {
+		shift += fract.FromInt(r.Dx())
+	}
+
+	// find nearest caret
+	feed.Reset()
+	feed.Renderer = theme.Text()
+	fx := fract.FromInt(x)
+	feed.Position.X = fract.FromInt(r.Min.X) + shift
+	closestDist := (fx - feed.Position.X).Abs()
+	for i, r := range w.textRunes {
+		feed.Advance(r)
+		dist := (fx - feed.Position.X).Abs()
+		if dist > closestDist { // prev was best
+			return i
+		}
+		closestDist = dist
+	}
+	return len(w.textRunes)
 }
 
 // Reset clears the current text.

--- a/widget/textinput.go
+++ b/widget/textinput.go
@@ -163,7 +163,7 @@ func (w *TextInput) Update(ctx *uikit.Context) {
 	}
 	if w.inputLimitTick > 0 {
 		w.inputLimitTick += 1
-		if w.inputLimitTick > (ebiten.TPS()*2)/5 {
+		if w.inputLimitTick > ebiten.TPS()/3 {
 			w.inputLimitTick = 0
 		}
 	}
@@ -355,12 +355,19 @@ func (w *TextInput) Draw(ctx *uikit.Context, dst *ebiten.Image) {
 		}
 	}
 
+	// compute text shake for hitting input limit
+	var yShake int
+	if w.inputLimitTick > 0 {
+		elapsed := float64(w.inputLimitTick) / float64(max(ebiten.TPS(), 1))
+		yShake = int(math.Round(math.Mod(elapsed*36, 3.0) - 1.25))
+	}
+
 	// draw text
 	shift := -scrollShift
 	if w.anchorRight {
 		shift += width
 	}
-	renderer.Draw(dst, w.text, r.Min.X+shift, cy)
+	renderer.Draw(dst, w.text, r.Min.X+shift, cy+yShake)
 
 	// draw caret
 	if w.IsFocused() && w.IsEnabled() && theme.CaretWidthPx > 0 && w.blink(theme) {

--- a/widget/textinput.go
+++ b/widget/textinput.go
@@ -31,6 +31,9 @@ type TextInput struct {
 	IMEOptions uikit.IMEOptions
 	OnCommit   func(*uikit.Context)
 
+	inputRuneLimit int
+	inputLimitTick int
+
 	// Reusable buffers to avoid allocations on every Update().
 	textRunes []rune
 	appendBuf []rune
@@ -75,6 +78,17 @@ func (w *TextInput) SetTextSilently(s string) {
 	}
 	w.caretPos = min(w.caretPos, len(w.textRunes))
 	w.scrollPos = max(0, w.scrollPos)
+}
+
+// SetInputRuneLimit limits the max number of code points that can be
+// entered by the user.
+//
+// Notice that this doesn't apply retroactively nor to manual operations
+// like [TextInput.SetText]().
+//
+// If limit <= 0, the input is unlimited.
+func (w *TextInput) SetInputRuneLimit(limit int) {
+	w.inputRuneLimit = max(limit, 0)
 }
 
 // Caret returns the current caret index, in runes.
@@ -147,6 +161,12 @@ func (w *TextInput) Update(ctx *uikit.Context) {
 			w.wasFocused = !w.wasFocused
 		}
 	}
+	if w.inputLimitTick > 0 {
+		w.inputLimitTick += 1
+		if w.inputLimitTick > (ebiten.TPS()*2)/5 {
+			w.inputLimitTick = 0
+		}
+	}
 
 	if !w.IsEnabled() {
 		return
@@ -172,9 +192,14 @@ func (w *TextInput) Update(ctx *uikit.Context) {
 		case r == 0x7f: // DEL
 			changed = w.deleteRuneDEL() || changed
 		case r >= 0x20: // append runes >= ' ' (ignore control chars)
-			w.textRunes = slices.Insert(w.textRunes, w.caretPos, r) // could be optimized
-			w.caretPos += 1
-			changed = true
+			if w.inputRuneLimit == 0 || len(w.textRunes) < w.inputRuneLimit {
+				w.textRunes = slices.Insert(w.textRunes, w.caretPos, r) // could be optimized
+				w.caretPos += 1
+				changed = true
+			} else {
+				w.caretTick = 0
+				w.inputLimitTick = 1
+			}
 		}
 	}
 
@@ -345,7 +370,11 @@ func (w *TextInput) Draw(ctx *uikit.Context, dst *ebiten.Image) {
 		b := dst.Bounds()
 		cy -= b.Min.Y
 		x -= b.Min.X
-		w.Base.DrawRoundedRect(dst, image.Rect(x, cy, x+theme.CaretWidthPx, cy+lineHeight), 0, theme.CaretColor)
+		clr := theme.CaretColor
+		if w.inputLimitTick > 0 {
+			clr = theme.ErrorTextColor
+		}
+		w.Base.DrawRoundedRect(dst, image.Rect(x, cy, x+theme.CaretWidthPx, cy+lineHeight), 0, clr)
 	}
 }
 

--- a/widget/textinput.go
+++ b/widget/textinput.go
@@ -29,6 +29,7 @@ type TextInput struct {
 	wasFocused  bool
 
 	IMEOptions uikit.IMEOptions
+	OnCommit   func(*uikit.Context)
 
 	// Reusable buffers to avoid allocations on every Update().
 	textRunes []rune
@@ -192,7 +193,11 @@ func (w *TextInput) Update(ctx *uikit.Context) {
 
 	// remove focus on Enter
 	if inpututil.IsKeyJustPressed(ebiten.KeyEnter) || inpututil.IsKeyJustPressed(ebiten.KeyKPEnter) {
-		ctx.SetFocus(nil)
+		if w.OnCommit != nil {
+			w.OnCommit(ctx)
+		} else {
+			ctx.SetFocus(nil)
+		}
 	}
 }
 
@@ -342,5 +347,9 @@ func (w *TextInput) Draw(ctx *uikit.Context, dst *ebiten.Image) {
 }
 
 func (w *TextInput) blink(theme *uikit.Theme) bool {
-	return (w.caretTick/blinkTicks(theme))%2 == 0
+	ticks := blinkTicks(theme)
+	if ticks <= 0 {
+		return false
+	}
+	return (w.caretTick/ticks)%2 == 0
 }


### PR DESCRIPTION
This PR enhances text edition for `widget.TextInput`:
- Navigation: caret can be moved both with keys or pressing/touching on the screen. When pressing left/right, it's also possible to hold `CONTROL` to skip a text fragment, and `HOME`/`END` or `PageUp`/`PageDown` to jump to start/end of the text.
- Insertion: updated to respect caret position within text.
- Deletion: backspace deletes previous character, but `DEL` deletes the next one, like in regular editors. For compatibility, pressing DEL when the cursor is at the end of the text is treated like backspace. If `CONTROL` is pressed, a text fragment is deleted instead.

This has also been tested for mobile with gboard.

`TextArea` hasn't been changed as the logic is fairly different and horizontal scroll is not implemented in any form yet.