### PR TITLE
Add PointerMapper for offscreen pointer projection

### DIFF
--- a/common/mapper.go
+++ b/common/mapper.go
@@ -1,0 +1,29 @@
+package common
+
+import (
+	"image"
+	"math"
+)
+
+// PointerMapper is a reference implementation for uikit.Context.PointerMapper
+// that allows adjusting pointer coordinates when drawing UI from an offscreen.
+type PointerMapper struct {
+	Target    image.Rectangle
+	Offscreen image.Rectangle
+}
+
+// Project matches the function signature for uikit.Context.PointerMapper.
+func (m *PointerMapper) Project(ptr image.Point) image.Point {
+	scale := func(from, to, at int) int {
+		if from == 0 {
+			return at
+		}
+		s := float64(to) / float64(from)
+		return int(math.Round(s * float64(at)))
+	}
+
+	ptr = ptr.Sub(m.Target.Min)
+	ptr.X = scale(m.Target.Dx(), m.Offscreen.Dx(), ptr.X)
+	ptr.Y = scale(m.Target.Dy(), m.Offscreen.Dy(), ptr.Y)
+	return ptr.Add(m.Offscreen.Min)
+}

--- a/context.go
+++ b/context.go
@@ -279,7 +279,7 @@ func (c *Context) topmostAt(pos image.Point) Widget {
 func (c *Context) Update() {
 	c.readPointerSnapshot()
 	c.root.SetHeight(c.dstBounds.Dy())
-	c.root.SetFrame(c.dstBounds.Min.X, c.dstBounds.Min.X, c.dstBounds.Dx())
+	c.root.SetFrame(c.dstBounds.Min.X, c.dstBounds.Min.Y, c.dstBounds.Dx())
 	c.root.Update(c)
 
 	c.rebuildWidgets()

--- a/context.go
+++ b/context.go
@@ -20,6 +20,13 @@ type Context struct {
 	hasTouch       bool
 	prevTouches    map[ebiten.TouchID]struct{}
 	dstBounds      image.Rectangle
+
+	// PointerMapper receives a coordinate pair consistent with
+	// Game.Layout and returns the corresponding offscreen position.
+	//
+	// This allows arbitrary pointer projections when the UI has to
+	// be drawn to an offscreen first and then projected.
+	PointerMapper func(image.Point) image.Point
 }
 
 func NewContext(theme *Theme, root Layout, ime IMEBridge) *Context {
@@ -224,6 +231,9 @@ func (c *Context) readPointerSnapshot() {
 			c.ptr.IsDown = true
 			c.ptr.IsTouch = true
 			c.ptr.Position.X, c.ptr.Position.Y = ebiten.TouchPosition(c.ptr.TouchID)
+			if c.PointerMapper != nil {
+				c.ptr.Position = c.PointerMapper(c.ptr.Position)
+			}
 		} else {
 			c.ptr.IsDown = false
 			c.ptr.IsTouch = true
@@ -235,6 +245,9 @@ func (c *Context) readPointerSnapshot() {
 	}
 
 	c.ptr.Position.X, c.ptr.Position.Y = ebiten.CursorPosition()
+	if c.PointerMapper != nil {
+		c.ptr.Position = c.PointerMapper(c.ptr.Position)
+	}
 	c.ptr.IsDown = ebiten.IsMouseButtonPressed(ebiten.MouseButtonLeft)
 	c.ptr.IsJustDown = inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft)
 	c.ptr.IsJustUp = inpututil.IsMouseButtonJustReleased(ebiten.MouseButtonLeft)
@@ -266,7 +279,7 @@ func (c *Context) topmostAt(pos image.Point) Widget {
 func (c *Context) Update() {
 	c.readPointerSnapshot()
 	c.root.SetHeight(c.dstBounds.Dy())
-	c.root.SetFrame(0, 0, c.dstBounds.Dx())
+	c.root.SetFrame(c.dstBounds.Min.X, c.dstBounds.Min.X, c.dstBounds.Dx())
 	c.root.Update(c)
 
 	c.rebuildWidgets()


### PR DESCRIPTION
This PR adds a configurable `PointerMapper` callback to `Context` which allows arbitrary pointer projections when the UI has to be drawn to an offscreen first and then projected.

It also adds a basic pointer mapper implementation to `common` which covers the most common use-cases, but it's neither exhaustive nor strictly necessary.