### PR TITLE
Move layouting to SetFrame

### DIFF
--- a/context.go
+++ b/context.go
@@ -19,6 +19,7 @@ type Context struct {
 	clickStartRect image.Rectangle
 	hasTouch       bool
 	prevTouches    map[ebiten.TouchID]struct{}
+	dstBounds      image.Rectangle
 
 	// PointerMapper receives a coordinate pair consistent with
 	// Game.Layout and returns the corresponding offscreen position.
@@ -278,7 +279,10 @@ func (c *Context) topmostAt(pos image.Point) Widget {
 func (c *Context) Update() {
 	c.readPointerSnapshot()
 	c.root.Update(c)
+
 	c.rebuildWidgets()
+	c.root.SetHeight(c.dstBounds.Dy())
+	c.root.SetFrame(c.dstBounds.Min.X, c.dstBounds.Min.Y, c.dstBounds.Dx())
 
 	if inpututil.IsKeyJustPressed(ebiten.KeyTab) {
 		if ebiten.IsKeyPressed(ebiten.KeyShift) {
@@ -340,9 +344,8 @@ func (c *Context) Draw(dst *ebiten.Image) {
 		return
 	}
 
-	bounds := dst.Bounds()
-	c.root.SetHeight(bounds.Dy())
-	c.root.SetFrame(bounds.Min.X, bounds.Min.Y, bounds.Dx())
+	c.dstBounds = dst.Bounds()
+	c.root.SetHeight(c.dstBounds.Dy())
 	c.root.Draw(c, dst)
 	c.root.DrawOverlay(c, dst)
 }

--- a/context.go
+++ b/context.go
@@ -19,7 +19,6 @@ type Context struct {
 	clickStartRect image.Rectangle
 	hasTouch       bool
 	prevTouches    map[ebiten.TouchID]struct{}
-	dstBounds      image.Rectangle
 
 	// PointerMapper receives a coordinate pair consistent with
 	// Game.Layout and returns the corresponding offscreen position.
@@ -278,10 +277,7 @@ func (c *Context) topmostAt(pos image.Point) Widget {
 
 func (c *Context) Update() {
 	c.readPointerSnapshot()
-	c.root.SetHeight(c.dstBounds.Dy())
-	c.root.SetFrame(c.dstBounds.Min.X, c.dstBounds.Min.Y, c.dstBounds.Dx())
 	c.root.Update(c)
-
 	c.rebuildWidgets()
 
 	if inpututil.IsKeyJustPressed(ebiten.KeyTab) {
@@ -344,7 +340,9 @@ func (c *Context) Draw(dst *ebiten.Image) {
 		return
 	}
 
-	c.dstBounds = dst.Bounds()
+	bounds := dst.Bounds()
+	c.root.SetHeight(bounds.Dy())
+	c.root.SetFrame(bounds.Min.X, bounds.Min.Y, bounds.Dx())
 	c.root.Draw(c, dst)
 	c.root.DrawOverlay(c, dst)
 }

--- a/layout/grid.go
+++ b/layout/grid.go
@@ -84,7 +84,6 @@ func (l *Grid) Update(ctx *uikit.Context) {
 	if l.height > 0 {
 		l.Scroller.Update(ctx, l.Measure(false), l.contentH)
 	}
-	l.doLayout(ctx)
 
 	for _, ch := range l.children {
 		if !ch.IsVisible() {
@@ -94,7 +93,12 @@ func (l *Grid) Update(ctx *uikit.Context) {
 	}
 }
 
-func (l *Grid) doLayout(ctx *uikit.Context) {
+func (l *Grid) SetFrame(x, y, width int) {
+	l.Base.SetFrame(x, y, width)
+	l.doLayout()
+}
+
+func (l *Grid) doLayout() {
 	vp := l.Measure(false)
 	cols := l.columns
 	if cols <= 0 {

--- a/layout/row_stack.go
+++ b/layout/row_stack.go
@@ -218,7 +218,6 @@ func (l *RowStack) Update(ctx *uikit.Context) {
 	if l.BeforeUpdate != nil {
 		l.BeforeUpdate(ctx, l)
 	}
-	l.doLayout(ctx)
 	if l.height > 0 {
 		l.Scroller.Update(ctx, l.Measure(false), l.contentH)
 	}
@@ -231,7 +230,12 @@ func (l *RowStack) Update(ctx *uikit.Context) {
 	}
 }
 
-func (l *RowStack) doLayout(ctx *uikit.Context) {
+func (l *RowStack) SetFrame(x, y, width int) {
+	l.Base.SetFrame(x, y, width)
+	l.doLayout()
+}
+
+func (l *RowStack) doLayout() {
 	area := l.Measure(false)
 
 	ox := area.Min.X + l.padX

--- a/layout/stack.go
+++ b/layout/stack.go
@@ -76,18 +76,20 @@ func (l *Stack) Update(ctx *uikit.Context) {
 	if l.height > 0 {
 		l.Scroller.Update(ctx, r, l.contentH)
 	}
-	l.doLayout(ctx)
 
 	for _, w := range l.children {
-		if !w.IsVisible() {
-			continue
+		if w.IsVisible() {
+			w.Update(ctx)
 		}
-
-		w.Update(ctx)
 	}
 }
 
-func (l *Stack) doLayout(ctx *uikit.Context) {
+func (l *Stack) SetFrame(x, y, width int) {
+	l.Base.SetFrame(x, y, width)
+	l.doLayout()
+}
+
+func (l *Stack) doLayout() {
 	vp := l.Measure(false)
 	x := vp.Min.X + l.padX
 	y := vp.Min.Y + l.padY - l.Scroller.ScrollY


### PR DESCRIPTION
This PR tries to improve layouting consistency and reduce content jumps by continuing to move layouting logic into `SetFrame` instead of `Update` or `Draw`.

------

For best layouting and to reduce content jumps and flickering, we've seen that all widgets should update their own height when their width changes. The best way to do this was on `SetFrame` itself.

But while many widgets have been updated to operate like this, layouts still handled layouting on their own update instead of on `SetFrame`, which is the most logical place to perform the operation:
- If layouting is done on `Layout.Update`, either before or after updating children, and layouts haven't used `SetFrame` to do their own layouting (which they can't because it would be duplicating logic), any update hook that removes, adds or changes the height or visibility of components will need multiple frames to stabilize.
- Doing layouting both on update and draw can reduce issues, but that's wasteful and can expose an inconsistent layout tree during update.

Therefore, layouting has been moved into `SetFrame` for layouts too, and `SetFrame` is called on `Context.Update` after widgets themselves are updated.